### PR TITLE
Add Playwright Test: Navigate to EPAM and verify Client Work

### DIFF
--- a/tests/navigate-to-epam-and-verify-client-work.spec.ts
+++ b/tests/navigate-to-epam-and-verify-client-work.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Navigate to EPAM and verify Client Work page', async ({ page }) => {
+  // Navigate to EPAM homepage
+  await page.goto('https://www.epam.com/');
+
+  // Click on "Services" from the header menu
+  await page.getByRole('link', { name: 'Services' }).click();
+
+  // Click on "Explore Our Client Work" link
+  await page.getByRole('link', { name: 'Explore Our Client Work' }).click();
+
+  // Verify "Client Work" text is visible
+  const clientWorkText = await page.getByText('Client Work').first();
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
### Scenario
Navigate to https://www.epam.com/, select "Services" from the header menu, click the "Explore Our Client Work" link, and verify that the "Client Work" text is visible.

### Test Execution Summary
**Result:** Pass

### Test Code
```typescript
import { test, expect } from '@playwright/test';

test('Navigate to EPAM and verify Client Work page', async ({ page }) => {
  // Navigate to EPAM homepage
  await page.goto('https://www.epam.com/');

  // Click on "Services" from the header menu
  await page.getByRole('link', { name: 'Services' }).click();

  // Click on "Explore Our Client Work" link
  await page.getByRole('link', { name: 'Explore Our Client Work' }).click();

  // Verify "Client Work" text is visible
  const clientWorkText = await page.getByText('Client Work').first();
  await expect(clientWorkText).toBeVisible();
});
```

### Evidence
- **Screenshots:** Captured during test execution
- **Logs:** Available upon request